### PR TITLE
feat: add food analysis endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Food AI Server
+
+Серверless-функция для анализа еды по фото, подсчёта калорий и рекомендаций.
+
+## Запуск локально
+
+1. Установи Node.js версии 18 или новее.
+2. Склонируй репозиторий и перейди в папку `api`.
+3. Сохрани ключ OpenAI в переменную окружения:
+   ```bash
+   export OPENAI_API_KEY="твой_ключ"
+   ```
+4. Запусти тесты:
+   ```bash
+   npm test
+   ```
+5. Для локального запуска установи [Vercel CLI](https://vercel.com/docs/cli):
+   ```bash
+   npm install -g vercel
+   vercel dev
+   ```
+   Эндпоинт будет доступен по адресу `http://localhost:3000/food`.
+
+## Деплой
+
+1. Авторизуйся в Vercel:
+   ```bash
+   vercel login
+   ```
+2. Выполни команду:
+   ```bash
+   vercel
+   ```
+3. Следуй подсказкам в терминале. После деплоя получишь URL вида `https://твое-приложение.vercel.app/food`.
+
+При каждом запросе отправляй POST JSON с полями `imageBase64`, `currentWeight` и `targetWeight`.

--- a/ai-server/api.js
+++ b/ai-server/api.js
@@ -1,48 +1,87 @@
+function calculateAchievements(currentWeight, targetWeight) {
+  const delta = currentWeight - targetWeight;
+  const achievements = [];
+
+  if (delta <= 0) {
+    achievements.push('Цель достигнута! Продолжай в том же духе.');
+  } else if (delta < 5) {
+    achievements.push('Почти у цели! Осталось меньше 5 кг.');
+  } else {
+    achievements.push('Отличное начало! Держи курс на здоровый рацион.');
+  }
+
+  return achievements;
+}
+
 module.exports = async function (req, res) {
-  // Только POST-запросы
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Только POST' });
   }
 
-  const { business, revenue, hours } = req.body;
+  const { imageBase64, currentWeight, targetWeight } = req.body;
 
-  // Проверяем данные
-  if (!business || !revenue || !hours) {
+  if (!imageBase64 || !currentWeight || !targetWeight) {
     return res.status(400).json({ error: 'Не хватает данных' });
   }
 
-  // Твой OpenAI API ключ (его ты вставишь в Vercel позже)
   const OPENAI_KEY = process.env.OPENAI_API_KEY;
+  if (!OPENAI_KEY) {
+    return res.status(500).json({ error: 'Отсутствует ключ API' });
+  }
 
-  // Запрос к ИИ
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      "Authorization": `Bearer ${OPENAI_KEY}`,
-      "Content-Type": "application/json"
-    },
-    body: JSON.stringify({
-      model: "gpt-3.5-turbo",
-      messages: [
-        {
-          role: "system",
-          content: "Ты эксперт по внедрению ИИ в бизнес. Выдай 3 короткие персональные рекомендации."
-        },
-        {
-          role: "user",
-          content: `Бизнес: ${business}. Выручка: ${revenue} руб/мес. Теряют ${hours} часов в неделю на рутину. Что посоветуешь?`
-        }
-      ],
-      max_tokens: 200
-    })
-  });
+  const prompt = `Проанализируй блюдо на фото и оцени калорийность. Текущий вес: ${currentWeight} кг. Целевой вес: ${targetWeight} кг. Дай три рекомендации для достижения цели и предложи три полезных рецепта. Ответ верни в формате JSON: { "analysis": string, "calories": number, "recommendations": string[], "recipes": string[] }`;
 
-  const data = await response.json();
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${OPENAI_KEY}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: 'Ты нутрициолог и помощник по здоровому питанию.' },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: prompt },
+              {
+                type: 'image_url',
+                image_url: { url: `data:image/jpeg;base64,${imageBase64}` }
+              }
+            ]
+          }
+        ],
+        max_tokens: 500,
+        response_format: { type: 'json_object' }
+      })
+    });
 
-  // Отправляем ответ на сайт
-  if (data.choices) {
-    res.json({ text: data.choices[0].message.content });
-  } else {
-    res.status(500).json({ error: "Ошибка ИИ" });
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({ error: 'Ошибка запроса к OpenAI', details: errorText });
+    }
+
+    const data = await response.json();
+
+    const content = data?.choices?.[0]?.message?.content;
+    if (!content) {
+      return res.status(500).json({ error: 'Ошибка ИИ' });
+    }
+
+    let result;
+    try {
+      result = JSON.parse(content);
+    } catch {
+      return res.status(500).json({ error: 'Неверный ответ ИИ' });
+    }
+
+    result.achievements = calculateAchievements(currentWeight, targetWeight);
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: 'Сбой соединения с OpenAI' });
   }
 };
+
+module.exports.calculateAchievements = calculateAchievements;

--- a/ai-server/api.test.js
+++ b/ai-server/api.test.js
@@ -1,0 +1,18 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { calculateAchievements } = require('./api');
+
+test('calculateAchievements returns correct messages', () => {
+  assert.deepStrictEqual(
+    calculateAchievements(70, 70),
+    ['Цель достигнута! Продолжай в том же духе.']
+  );
+  assert.deepStrictEqual(
+    calculateAchievements(73, 70),
+    ['Почти у цели! Осталось меньше 5 кг.']
+  );
+  assert.deepStrictEqual(
+    calculateAchievements(80, 70),
+    ['Отличное начало! Держи курс на здоровый рацион.']
+  );
+});

--- a/ai-server/vercel.json
+++ b/ai-server/vercel.json
@@ -8,7 +8,7 @@
   ],
   "routes": [
     {
-      "src": "/api",
+      "src": "/food",
       "dest": "api.js"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ai-server",
+  "version": "1.0.0",
+  "description": "Serverless food analysis endpoint",
+  "scripts": {
+    "test": "node --test ai-server/api.test.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add endpoint that analyzes meal photos and returns calories, recommendations and recipes
- expose the new endpoint at `/food`
- add input validation, better error handling and weight achievement helper
- fix OpenAI request format for image content
- add basic tests, package.json and usage instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894f95413e8832395e89faa83ac6394